### PR TITLE
wider _GLIBCXX_DEBUG_BACKTRACE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Pyarelal Knowles, MIT License
+# Copyright (c) 2024-2025 Pyarelal Knowles, MIT License
 
 cmake_minimum_required(VERSION 3.20)
 
@@ -22,7 +22,7 @@ if(NOT TARGET decodeless::allocator)
     FetchContent_Declare(
       decodeless_allocator
       GIT_REPOSITORY https://github.com/decodeless/allocator.git
-      GIT_TAG 976a34bd7f9784839dd9bba05262001a498f5ce4)
+      GIT_TAG 9b45b23ea556ae5ec42af4ce60b13bd3a7db8a8f)
     FetchContent_MakeAvailable(decodeless_allocator)
   else()
     message(
@@ -43,7 +43,7 @@ if(NOT TARGET decodeless::mappedfile)
     FetchContent_Declare(
       decodeless_mappedfile
       GIT_REPOSITORY https://github.com/decodeless/mappedfile.git
-      GIT_TAG bbd066e089210ac06063a9d4e278749b275fffe9)
+      GIT_TAG a6e59f8b193298a16534beab694e30ae76d7f457)
     FetchContent_MakeAvailable(decodeless_mappedfile)
   else()
     message(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Pyarelal Knowles, MIT License
+# Copyright (c) 2024-2025 Pyarelal Knowles, MIT License
 
 cmake_minimum_required(VERSION 3.20)
 
@@ -24,7 +24,7 @@ if(NOT TARGET decodeless::offset_ptr)
     FetchContent_Declare(
       decodeless_offset_ptr
       GIT_REPOSITORY https://github.com/decodeless/offset_ptr.git
-      GIT_TAG 1f87a9d7a8be23b90c06124014f286df91562006)
+      GIT_TAG 38ceefc6ce63fb4667cd207424b1277c3eed5f8d)
     FetchContent_MakeAvailable(decodeless_offset_ptr)
   else()
     message(
@@ -39,8 +39,6 @@ add_executable(${PROJECT_NAME}_tests src/writer.cpp)
 target_link_libraries(${PROJECT_NAME}_tests decodeless::writer
                       decodeless::offset_ptr gtest_main gmock_main)
 
-# TODO: presets?
-# https://stackoverflow.com/questions/45955272/modern-way-to-set-compiler-flags-in-cross-platform-cmake-project
 if(MSVC)
   target_compile_options(${PROJECT_NAME}_tests PRIVATE /W4 /WX)
   target_compile_definitions(${PROJECT_NAME}_tests PRIVATE WIN32_LEAN_AND_MEAN=1
@@ -49,17 +47,20 @@ else()
   target_compile_options(${PROJECT_NAME}_tests PRIVATE -Wall -Wextra -Wpedantic
                                                        -Werror)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(
-      ${PROJECT_NAME}_tests
-      PRIVATE $<$<CONFIG:Debug>:-D_GLIBCXX_DEBUG>
-              $<$<CONFIG:Debug>:-D_GLIBCXX_DEBUG_BACKTRACE>)
-    try_compile(
-      HAS_STDCXX_LIBBACKTRACE SOURCE_FROM_CONTENT
-      stdc++_libbacktrace_test.cpp "int main() { return 0; }"
-      LINK_LIBRARIES stdc++_libbacktrace)
-    if(HAS_STDCXX_LIBBACKTRACE)
+    target_compile_definitions(${PROJECT_NAME}_tests
+                               PRIVATE $<$<CONFIG:Debug>:_GLIBCXX_DEBUG>)
+
+    # Ugly detection for a working _GLIBCXX_DEBUG_BACKTRACE config, but the
+    # feature itself is useful
+    include(glibcxx_debug_backtrace.cmake)
+    if(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+      target_compile_definitions(
+        ${PROJECT_NAME}_tests
+        PRIVATE $<$<CONFIG:Debug>:_GLIBCXX_DEBUG_BACKTRACE>)
       target_link_libraries(${PROJECT_NAME}_tests
-                            $<$<CONFIG:Debug>:stdc++_libbacktrace>)
+                            $<$<CONFIG:Debug>:${GLIBCXX_DEBUG_BACKTRACE_LIBRARY}>)
+      target_compile_features(${PROJECT_NAME}_tests
+                              PRIVATE ${GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE})
     endif()
   endif()
 

--- a/test/glibcxx_debug_backtrace.cmake
+++ b/test/glibcxx_debug_backtrace.cmake
@@ -1,0 +1,73 @@
+# Copyright (c) 2025 Pyarelal Knowles, MIT License
+
+if(NOT DEFINED GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED false)
+endif()
+
+# Try default build with no extra libraries
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_JUSTWORKS SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE)
+  if(DEBUG_BACKTRACE_JUSTWORKS)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE)
+  endif()
+endif()
+
+# Try C++23 with no extra libraries
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_NEEDCXX23 SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE
+                        CXX_STANDARD 23 CXX_STANDARD_REQUIRED true)
+  if(DEBUG_BACKTRACE_NEEDCXX23)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE cxx_std_23)
+  endif()
+endif()
+
+# Try with libstdc++exp
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_NEEDSTDEXP SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE CXX_STANDARD
+                        20 CXX_STANDARD_REQUIRED true
+    LINK_LIBRARIES stdc++exp)
+  if(DEBUG_BACKTRACE_NEEDSTDEXP)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY stdc++exp)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE)
+  endif()
+endif()
+
+# Try with libstdc++_libbacktrace
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  try_compile(
+    DEBUG_BACKTRACE_NEEDLIBBACKTRACE SOURCE_FROM_CONTENT
+    stdc++_libbacktrace_test.cpp
+    "#include <vector>\nint main() { std::vector<int> v{0}; return v[0]; }"
+    COMPILE_DEFINITIONS -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_BACKTRACE CXX_STANDARD
+                        20 CXX_STANDARD_REQUIRED true
+    LINK_LIBRARIES stdc++_libbacktrace)
+  if(DEBUG_BACKTRACE_NEEDLIBBACKTRACE)
+    set(GLIBCXX_DEBUG_BACKTRACE_SUPPORTED true)
+    set(GLIBCXX_DEBUG_BACKTRACE_LIBRARY stdc++_libbacktrace)
+    set(GLIBCXX_DEBUG_BACKTRACE_CXX_FEATURE)
+  endif()
+endif()
+
+# Issue a warning if none of the above worked
+if(NOT GLIBCXX_DEBUG_BACKTRACE_SUPPORTED)
+  message(
+    WARNING "No working try_compile configs with _GLIBCXX_DEBUG_BACKTRACE found"
+  )
+endif()


### PR DESCRIPTION
Ugly scattering of try_compile tests for the different ways backtrace support can be provided by libstdc++

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project metadata and dependency references.
	- Refined the build configuration to enhance detection and support for advanced debug backtrace features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->